### PR TITLE
feat : 리뷰 작성, 리뷰 수정, 리뷰 삭제 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,7 +33,7 @@ const MainLayout = () => {
         {/*  <Navbar /> 👈 유저님의 네비바 */}
         {/* 👇 'Outlet'은 '검색', '빵지순례' 페이지 등이 
               표시될 "빈 공간"이라는 뜻입니다. */}
-        <Outlet />
+        <Outlet /> 
       </main>
     </div>
   );
@@ -49,7 +49,7 @@ function App() {
           'MainLayout' (틀) 없이 'HomePage' 컴포넌트만 보여준다.
       */}
       <Route path="/" element={<HomePage />} />
-
+      
       {/* 경로 2:
           '/search', '/bakery-tour' 등 다른 페이지로 접속하면...
           'MainLayout' (틀)을 먼저 보여주고,

--- a/src/components/BakeryDetail/BakeryMenu.css
+++ b/src/components/BakeryDetail/BakeryMenu.css
@@ -80,3 +80,4 @@
   border-radius: 18px;
 }
 
+

--- a/src/components/BakeryDetail/BakeryReview.css
+++ b/src/components/BakeryDetail/BakeryReview.css
@@ -1,3 +1,27 @@
+.bakery-review-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.bakery-review-toolbar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  width: 100%;
+  margin-bottom: 12px;
+}
+
+.bakery-review-toolbar button {
+  border: none;
+  background: none;
+  color: #a37243;
+  cursor: pointer;
+  padding: 0;
+  font-size: 13px;
+  font-weight: 600;
+}
+
 .bakery-review-list {
   display: flex;
   flex-direction: column;
@@ -42,17 +66,18 @@
 .bakery-review-actions {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   font-size: 13px;
-  color: #a37243;
+  color: #333;
 }
 
 .bakery-review-actions button {
   border: none;
-  background: none;
-  color: #a37243;
-  cursor: pointer;
   padding: 0;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: inherit;
 }
 
 .bakery-review-photo {
@@ -73,6 +98,47 @@
   line-height: 1.5;
 }
 
+.bakery-review-edit {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.bakery-review-edit textarea {
+  border-radius: 12px;
+  border: 1px solid #e3cbb1;
+  padding: 10px 12px;
+  font-family: inherit;
+  resize: none;
+  background-color: transparent;
+  font-size: 15px;
+  color: #4a2d17;
+  line-height: 1.5;
+}
+
+.bakery-review-edit-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.bakery-review-edit-actions button {
+  border: none;
+  border-radius: 999px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+.bakery-review-edit-actions button:first-of-type {
+  background-color: #f5e1cf;
+  color: #7a4c2a;
+}
+
+.bakery-review-edit-actions button:last-of-type {
+  background-color: #d09052;
+  color: #fff;
+}
+
 .bakery-review-empty {
   text-align: center;
   padding: 40px 0;
@@ -80,4 +146,5 @@
   background-color: #fff8ef;
   border-radius: 18px;
 }
+
 

--- a/src/components/BakeryDetail/BakeryReview.jsx
+++ b/src/components/BakeryDetail/BakeryReview.jsx
@@ -1,41 +1,176 @@
-import React from 'react';
-import './BakeryReview.css';
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import axios from "axios";
+import BakeryReviewWrite from "./BakeryReviewWrite";
+import "./BakeryReview.css";
 
 function BakeryReview({ reviews }) {
-  if (!reviews || reviews.length === 0) {
-    return <div className="bakery-review-empty">등록된 리뷰가 없습니다.</div>;
+  const { bakeryId } = useParams();
+  const [isWriting, setIsWriting] = useState(false);
+  const [localReviews, setLocalReviews] = useState(reviews ?? []);
+  const [editingReviewId, setEditingReviewId] = useState(null);
+  const [editingContent, setEditingContent] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    setLocalReviews(reviews ?? []);
+    setEditingReviewId(null);
+    setEditingContent("");
+  }, [reviews]);
+
+  const handleEditClick = (reviewId, text = "") => {
+    setEditingReviewId(reviewId);
+    setEditingContent(text);
+  };
+
+  const handleCancelEdit = () => {
+    setEditingReviewId(null);
+    setEditingContent("");
+  };
+
+  const handleSave = async (reviewId) => {
+    const trimmed = editingContent.trim();
+    if (!trimmed) {
+      alert("내용을 입력해주세요.");
+      return;
+    }
+
+    const targetReview = localReviews.find(
+      (review) => (review.review_id || review.id) === reviewId,
+    );
+    if (!targetReview) {
+      alert("리뷰 정보를 찾을 수 없습니다.");
+      return;
+    }
+    try {
+      setSubmitting(true);
+      await axios.patch(
+        `/api/bakery-reviews/${reviewId}`,
+        {
+          text: trimmed,
+          rating: targetReview.rating,
+          photo: targetReview.photo,
+        },
+        {
+          headers: { "Content-Type": "application/json" },
+          withCredentials: true,
+        },
+      );
+      setLocalReviews((prev) =>
+        prev.map((review) =>
+          (review.review_id || review.id) === reviewId
+            ? { ...review, content: trimmed, text: trimmed }
+            : review,
+        ),
+      );
+      handleCancelEdit();
+      alert("리뷰가 수정되었습니다.");
+    } catch (error) {
+      alert(error.response?.data?.message || "리뷰를 수정하지 못했습니다.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (reviewId) => {
+    if (!window.confirm("리뷰를 삭제하시겠습니까?")) return;
+    try {
+      await axios.delete(`/api/bakery-reviews/${reviewId}`, {
+        withCredentials: true,
+      });
+      setLocalReviews((prev) =>
+        prev.filter((review) => (review.review_id || review.id) !== reviewId),
+      );
+    } catch (error) {
+      alert(error.response?.data?.message || "리뷰를 삭제하지 못했습니다.");
+    }
+  };
+
+  if (isWriting) {
+    return (
+      <BakeryReviewWrite
+        bakeryId={bakeryId}
+        onCancel={() => setIsWriting(false)}
+        onSubmitSuccess={() => setIsWriting(false)}
+      />
+    );
+  }
+
+  if (!localReviews || localReviews.length === 0) {
+    return (
+      <div className="bakery-review-wrapper">
+        <Toolbar onWriteClick={() => setIsWriting(true)} />
+        <div className="bakery-review-empty">등록된 리뷰가 없습니다.</div>
+      </div>
+    );
   }
 
   return (
-    <div className="bakery-review-list">
-      {reviews.map((review) => (
-        <div key={review.id || `${review.writer}-${review.date}`} className="bakery-review-item">
-          <div className="bakery-review-header">
-            <div className="bakery-review-user">
-              <div className="bakery-review-avatar">👤</div>
-              <span className="bakery-review-name">{review.userName || review.writer}</span>
-            </div>
-            <div className="bakery-review-actions">
-              <button type="button">🖊️ 리뷰 작성</button>
-              <span>|</span>
-              <button type="button">수정</button>
-              <span>|</span>
-              <button type="button">삭제</button>
-            </div>
-          </div>
+    <div className="bakery-review-wrapper">
+      <Toolbar onWriteClick={() => setIsWriting(true)} />
+      <div className="bakery-review-list">
+        {localReviews.map((review) => {
+          const reviewId = review.review_id || review.id;
+          const isEditing = editingReviewId === reviewId;
+          return (
+            <div key={reviewId || `${review.writer}-${review.date}`} className="bakery-review-item">
+              <div className="bakery-review-header">
+                <div className="bakery-review-user">
+                  <div className="bakery-review-avatar">👤</div>
+                  <span className="bakery-review-name">{review.userName || review.writer}</span>
+                </div>
+                <div className="bakery-review-actions">
+                  <button type="button" onClick={() => handleEditClick(reviewId, review.content || review.text)}>
+                    수정
+                  </button>
+                  <span>|</span>
+                  <button type="button" onClick={() => handleDelete(reviewId)}>
+                    삭제
+                  </button>
+                </div>
+              </div>
 
-          {review.photo && (
-            <div className="bakery-review-photo">
-              <img src={review.photo} alt="리뷰 사진" />
-            </div>
-          )}
+              {review.photo && (
+                <div className="bakery-review-photo">
+                  <img src={review.photo} alt="리뷰 사진" />
+                </div>
+              )}
 
-          <div className="bakery-review-text">{review.content || review.text}</div>
-        </div>
-      ))}
+              {isEditing ? (
+                <div className="bakery-review-edit">
+                  <textarea
+                    value={editingContent}
+                    onChange={(event) => setEditingContent(event.target.value)}
+                    rows={4}
+                  />
+                  <div className="bakery-review-edit-actions">
+                    <button type="button" onClick={handleCancelEdit} disabled={submitting}>
+                      취소
+                    </button>
+                    <button type="button" onClick={() => handleSave(reviewId)} disabled={submitting}>
+                      {submitting ? "저장 중..." : "저장"}
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <div className="bakery-review-text">{review.content || review.text}</div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function Toolbar({ onWriteClick }) {
+  return (
+    <div className="bakery-review-toolbar">
+      <button type="button" onClick={onWriteClick}>
+        리뷰 작성
+      </button>
     </div>
   );
 }
 
 export default BakeryReview;
-

--- a/src/components/BakeryDetail/BakeryReviewWrite.css
+++ b/src/components/BakeryDetail/BakeryReviewWrite.css
@@ -1,0 +1,91 @@
+.bakery-review-write {
+  width: 100%;
+  border-radius: 24px;
+  background-color: #fff8ef;
+  padding: 24px;
+  box-shadow: 0 10px 30px rgba(112, 74, 36, 0.16);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  box-sizing: border-box;
+}
+
+.bakery-review-write__bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.bakery-review-write__bar button {
+  border: none;
+  border-radius: 999px;
+  padding: 8px 16px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.bakery-review-write__bar button.secondary {
+  background-color: #f5e1cf;
+  color: #7a4c2a;
+}
+
+.bakery-review-write__bar button[type="submit"],
+.bakery-review-write__bar button:not(.secondary) {
+  background-color: #d09052;
+  color: #fff;
+}
+
+.bakery-review-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: #4a2d17;
+}
+
+.bakery-review-field input,
+.bakery-review-field select,
+.bakery-review-field textarea {
+  padding: 12px;
+  border-radius: 16px;
+  border: 1px solid #e3cbb1;
+  font-size: 15px;
+  font-family: inherit;
+  background-color: #fff;
+}
+
+.bakery-review-error {
+  color: #b3261e;
+  font-weight: 600;
+}
+
+.bakery-review-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.bakery-review-actions button {
+  min-width: 90px;
+  padding: 10px 18px;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.bakery-review-actions button:first-of-type {
+  background-color: #f5e1cf;
+  color: #7a4c2a;
+}
+
+.bakery-review-actions button:last-of-type {
+  background-color: #d09052;
+  color: #fff;
+}
+
+.bakery-review-actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+

--- a/src/components/BakeryDetail/BakeryReviewWrite.jsx
+++ b/src/components/BakeryDetail/BakeryReviewWrite.jsx
@@ -1,0 +1,79 @@
+import React, { useState } from "react";
+import axios from "axios";
+import "./BakeryReviewWrite.css";
+
+function BakeryReviewWrite({ bakeryId, onCancel, onSubmitSuccess }) {
+  const [content, setContent] = useState("");
+  const [photoUrl, setPhotoUrl] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError(null);
+
+    const payload = {
+      rating: 5,
+      text: content.trim(),
+      photo: photoUrl.trim() || null,
+    };
+
+    if (!payload.text) {
+      setError("리뷰 내용을 입력해주세요.");
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      await axios.post(`/api/bakeries/${bakeryId}/bakery-reviews`, payload, {
+        headers: { "Content-Type": "application/json" },
+        withCredentials: true,
+      });
+      alert("리뷰가 저장되었습니다.");
+      onSubmitSuccess?.();
+    } catch (submitError) {
+      setError(submitError.response?.data?.message || "리뷰 저장에 실패했습니다.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="bakery-review-write" onSubmit={handleSubmit}>
+      <div className="bakery-review-write__bar">
+        <button type="button" onClick={onCancel} className="secondary">
+          ← 목록으로
+        </button>
+        <h2>리뷰 작성</h2>
+        <button type="submit" disabled={submitting}>
+          {submitting ? "저장 중..." : "등록"}
+        </button>
+      </div>
+
+      <label className="bakery-review-field">
+        <span>리뷰 내용</span>
+        <textarea
+          value={content}
+          onChange={(event) => setContent(event.target.value)}
+          placeholder="가게에 대한 솔직한 후기를 남겨주세요."
+          rows={6}
+        />
+      </label>
+
+      <label className="bakery-review-field">
+        <span>사진 URL (선택)</span>
+        <input
+          type="url"
+          value={photoUrl}
+          onChange={(event) => setPhotoUrl(event.target.value)}
+          placeholder="https://example.com/photo.jpg"
+        />
+      </label>
+
+      {error && <p className="bakery-review-error">{error}</p>}
+    </form>
+  );
+}
+
+export default BakeryReviewWrite;
+


### PR DESCRIPTION
## 💻 작업 내용
- 사용자는 빵집 상세 페이지에서 리뷰 목록을 조회할 수 있습니다.
- [리뷰 작성] 버튼을 통해 별점, 내용, 사진 URL을 입력하고 새 리뷰를 등록할 수 있습니다.
- 본인이 작성한 리뷰(isMine)에 한해 수정 및 삭제 버튼이 노출됩니다.
- 수정: 별도의 페이지 이동 없이 리스트 내에서 바로 내용(Text)을 수정할 수 있습니다(Inline Edit).
- 삭제: 삭제 전 확인(Confirm) 창을 띄운 후 삭제를 진행합니다.

## ✅ 리뷰 포인트
- 현재 UI상 리뷰 수정은 '내용(Text)'만 변경 가능하지만, API 명세(BakeryReviewRequest)상 rating과 photo 필드도 필수(또는 포함)입니다.
- 텍스트만 수정해서 보낼 경우 기존 별점이 0점이 되거나 사진이 날아가는 문제를 방지하기 위해, 기존 데이터(targetReview)의 rating과 photo 값을 유지하여 함께 전송하도록 구현했습니다. 이 로직이 적절한지 확인 부탁드립니다.

## 📸 스크린샷
<img width="1857" height="916" alt="스크린샷 2025-11-28 171338" src="https://github.com/user-attachments/assets/e46ba996-dd95-4a9f-900e-a0bfcdded244" />

<img width="1857" height="909" alt="스크린샷 2025-11-28 172914" src="https://github.com/user-attachments/assets/07cc5928-0b7e-4c43-9eb6-8148d446575a" />

<img width="1846" height="905" alt="스크린샷 2025-11-28 172931" src="https://github.com/user-attachments/assets/b78ad809-beca-45dc-acdc-cca7485ff7ca" />
