### PR TITLE
fix: 프로덕션 환경에서 직접 백엔드 URL 사용하도록 변경

### DIFF
--- a/src/api/axiosConfig.js
+++ b/src/api/axiosConfig.js
@@ -8,10 +8,11 @@ const getBaseURL = () => {
     return "";
   }
 
-  // 프로덕션 환경: 빈 값 (vercel.json 프록시 사용)
-  // vercel.json의 rewrites를 통해 /api, /auth 요청이 백엔드로 프록시됨
-  console.log("🚀 프로덕션 환경: vercel.json 프록시 사용");
-  return "";
+  // 프로덕션 환경: 실제 API 서버 주소
+  const baseURL =
+    import.meta.env.VITE_API_BASE_URL || "https://breadcast.duckdns.org";
+  console.log("🚀 프로덕션 환경:", baseURL);
+  return baseURL;
 };
 
 const api = axios.create({


### PR DESCRIPTION
- vercel.json 프록시 대신 직접 백엔드 주소 사용
- VITE_API_BASE_URL 환경변수 또는 기본값 사용
- 백엔드 CORS 설정 완료로 인한 변경